### PR TITLE
Added ServoAngle and ServoAngles interface definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Telemetry.msg"
+  "msg/ServoAngle.msg"
+  "msg/ServoAngles.msg"
   "srv/Control.srv"
   DEPENDENCIES std_msgs
  )

--- a/msg/ServoAngle.msg
+++ b/msg/ServoAngle.msg
@@ -1,0 +1,2 @@
+string name
+uint8 angle

--- a/msg/ServoAngles.msg
+++ b/msg/ServoAngles.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+
+ServoAngle[] servos

--- a/srv/Control.srv
+++ b/srv/Control.srv
@@ -12,5 +12,6 @@ string set_charger
 string set_fet1
 string set_fet2
 string set_motors
+string set_servos
 ---
 bool success


### PR DESCRIPTION
ServoAngles contains a list of ServoAngle.

Required by [roboquest_core PR 6](https://github.com/billmania/roboquest_core/pull/6)