### PR TITLE
Added the motors_on and servos_on attributes to the Telemetry message

### DIFF
--- a/msg/Telemetry.msg
+++ b/msg/Telemetry.msg
@@ -26,3 +26,11 @@ bool charger_has_power
 # Is the battery being charged?
 #
 bool battery_charging
+#
+# Are the motors powered?
+#
+bool motors_on
+#
+# Are the servos powered?
+#
+bool servos_on

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rq_msgs</name>
-  <version>0.0.2</version>
+  <version>0.1.0</version>
   <description>Message definitions for RoboQuest.</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>


### PR DESCRIPTION
Nothing more to be said. Added to support indicators in the UI. Updated package.xml to 0.1.0.

This is not a breaking change for existing logic.

Tested by echoing the /telemetry topic while calling the /control_hat service and toggling all of set_motors, set_servos, and set_charger.