### PR TITLE
Defined the MotorSpeed message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Telemetry.msg"
+  "msg/MotorSpeed.msg"
   "msg/ServoAngle.msg"
   "msg/ServoAngles.msg"
   "srv/Control.srv"

--- a/msg/MotorSpeed.msg
+++ b/msg/MotorSpeed.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+
+uint8 max_speed

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rq_msgs</name>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
   <description>Message definitions for RoboQuest.</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>


### PR DESCRIPTION
To enable control of the maximum speed for drive motors, the message MotorSpeed was defined.

Tested by building everything and then publishing messages via both **ros2 topic pub** and a new slider widget in the UI.

Required by [rq_core PR 44](https://github.com/billmania/roboquest_core/pull/44) and [rq_ui PR 89](https://github.com/billmania/roboquest_ui/pull/89).