### PR TITLE
Renamed MotorSpeed.max_speed to max_rpm and changed its data type

### DIFF
--- a/msg/MotorSpeed.msg
+++ b/msg/MotorSpeed.msg
@@ -1,3 +1,3 @@
 std_msgs/Header header
 
-uint8 max_speed
+uint16 max_rpm


### PR DESCRIPTION
The unit for drive motor speed is RPM. Made adjustments to the MotorSpeed interface definition, changing the attribute name to max_rpm and changing its data type to uint16, to allow maximum speeds greater than 255.

Required by [rq_core PR 54](https://github.com/billmania/roboquest_core/pull/54) and [rq_ui PR 115](https://github.com/billmania/roboquest_ui/pull/115).