### PR TITLE
Replaced ServoAngle and ServoAngles with Servo and Servos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ find_package(std_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Telemetry.msg"
   "msg/MotorSpeed.msg"
-  "msg/ServoAngle.msg"
-  "msg/ServoAngles.msg"
+  "msg/Servo.msg"
+  "msg/Servos.msg"
   "srv/Control.srv"
   DEPENDENCIES std_msgs
  )

--- a/msg/Servo.msg
+++ b/msg/Servo.msg
@@ -6,16 +6,15 @@ uint8 angle_deg
 
 #
 # The amount to increment the current angle, without
-# controlling rate of change. Requires direction and
-# command_type 'I'.
+# controlling rate of change. Requires command_type 2.
 #
-uint8 angle_incr_deg
+int8 angle_incr_deg
 
 #
 # The speed to change the current angle. Requires
-# direction and command_type 'S'.
+# command_type 3.
 #
-uint8 speed_dps
+int8 speed_dps
 
 #
 # 1 when using angle_deg, 2 when using angle_incr_deg, or

--- a/msg/Servo.msg
+++ b/msg/Servo.msg
@@ -1,0 +1,35 @@
+#
+# An optional name for the servo
+#
+string name
+
+#
+# The angle to achieve, without controlling rate of change.
+# Requires command_type 'A'.
+#
+uint8 angle_deg
+
+#
+# The amount to increment the current angle, without
+# controlling rate of change. Requires direction and
+# command_type 'I'.
+#
+uint8 angle_incr_deg
+
+#
+# The speed to change the current angle. Requires
+# direction and command_type 'S'.
+#
+uint8 speed_dps
+
+#
+# '-' to rotate toward the zero angle or '+' to rotate away
+# from the zero angle.
+#
+string direction '+'
+
+#
+# 'A' when using angle_deg, 'I' when using angle_incr_deg, or
+# 'S' when using speed_dps. 'X' indicates to ignore this servo.
+#
+string command_type 'X'

--- a/msg/Servo.msg
+++ b/msg/Servo.msg
@@ -1,11 +1,6 @@
 #
-# An optional name for the servo
-#
-string name
-
-#
 # The angle to achieve, without controlling rate of change.
-# Requires command_type 'A'.
+# Requires command_type 1.
 #
 uint8 angle_deg
 
@@ -23,13 +18,7 @@ uint8 angle_incr_deg
 uint8 speed_dps
 
 #
-# '-' to rotate toward the zero angle or '+' to rotate away
-# from the zero angle.
+# 1 when using angle_deg, 2 when using angle_incr_deg, or
+# 3 when using speed_dps. 0 indicates to ignore this servo.
 #
-string direction '+'
-
-#
-# 'A' when using angle_deg, 'I' when using angle_incr_deg, or
-# 'S' when using speed_dps. 'X' indicates to ignore this servo.
-#
-string command_type 'X'
+uint8 command_type

--- a/msg/ServoAngle.msg
+++ b/msg/ServoAngle.msg
@@ -1,2 +1,0 @@
-string name
-uint8 angle

--- a/msg/ServoAngles.msg
+++ b/msg/ServoAngles.msg
@@ -1,3 +1,0 @@
-std_msgs/Header header
-
-ServoAngle[] servos

--- a/msg/Servos.msg
+++ b/msg/Servos.msg
@@ -1,0 +1,18 @@
+std_msgs/Header header
+
+Servo servo0
+Servo servo1
+Servo servo2
+Servo servo3
+Servo servo4
+Servo servo5
+Servo servo6
+Servo servo7
+Servo servo8
+Servo servo9
+Servo servo10
+Servo servo11
+Servo servo12
+Servo servo13
+Servo servo14
+Servo servo15

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rq_msgs</name>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <description>Message definitions for RoboQuest.</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>


### PR DESCRIPTION
The original way of commanding servos only supported setting a specific angle and allowed for a variable list of commands for a subset of servos. This complicated the communication from the browser UI and didn't allow for setting speeds or handling position increments directly.

So, ServoAngle was replaced with Servo and ServoAngles was replaced with Servos. Servos contains a static collection of 16 servos, which will simplify creation at the UI end. Servo supports all of: set an angle; apply an increment; and apply a rotational velocity.

Tested using rqt to publish Servos messages with command_type set to 1, 2, and 3 and adjusting the angle_deg, angle_incr_deg, and speed_dps.

Required by [rq_core PR 66](https://github.com/billmania/roboquest_core/pull/66)

https://github.com/billmania/rq_msgs/issues/8