### PR TITLE
Changed the type of angle_deg

### DIFF
--- a/msg/Servo.msg
+++ b/msg/Servo.msg
@@ -2,7 +2,7 @@
 # The angle to achieve, without controlling rate of change.
 # Requires command_type 1.
 #
-uint8 angle_deg
+uint16 angle_deg
 
 #
 # The amount to increment the current angle, without


### PR DESCRIPTION
Some servos can achieve an angle position greater than 255. Changed the type of Servo.angle_deg from uint8 to uint16 to enable this greater angle.

https://github.com/billmania/rq_msgs/issues/10

Required by [rq_core PR 69](https://github.com/billmania/roboquest_core/pull/69)